### PR TITLE
Removed save button from settings menu

### DIFF
--- a/src/Assets/Scenes/MainMenu.unity
+++ b/src/Assets/Scenes/MainMenu.unity
@@ -1671,7 +1671,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6323702144920913464, guid: b912bb47a8c07ecb0a1e9d239f6a7ede, type: 3}
       propertyPath: m_NormalizedViewPortRect.x
-      value: 0.029850747
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6323702144920913464, guid: b912bb47a8c07ecb0a1e9d239f6a7ede, type: 3}
       propertyPath: m_NormalizedViewPortRect.y
@@ -1679,7 +1679,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6323702144920913464, guid: b912bb47a8c07ecb0a1e9d239f6a7ede, type: 3}
       propertyPath: m_NormalizedViewPortRect.width
-      value: 0.94107246
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6323702144920913464, guid: b912bb47a8c07ecb0a1e9d239f6a7ede, type: 3}
       propertyPath: m_NormalizedViewPortRect.height
@@ -6356,6 +6356,30 @@ PrefabInstance:
       propertyPath: m_Camera
       value: 
       objectReference: {fileID: 818202750}
+    - target: {fileID: 859474346347558640, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 859474346347558640, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 859474346347558640, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 150
+      objectReference: {fileID: 0}
+    - target: {fileID: 859474346347558640, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 859474346347558640, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 75
+      objectReference: {fileID: 0}
+    - target: {fileID: 859474346347558640, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -15
+      objectReference: {fileID: 0}
     - target: {fileID: 1227972655589169717, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
@@ -6380,6 +6404,46 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
+    - target: {fileID: 1462920960059719081, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1462920960059719081, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1462920960059719081, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1462920960059719081, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1462920960059719081, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1462920960059719081, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1824040834879606056, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1824040834879606056, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1824040834879606056, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 1824040834879606056, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -10
+      objectReference: {fileID: 0}
     - target: {fileID: 1966888155942825671, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
@@ -6399,6 +6463,38 @@ PrefabInstance:
     - target: {fileID: 2862359415338497742, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
       propertyPath: m_Name
       value: MenuController
+      objectReference: {fileID: 0}
+    - target: {fileID: 3807793465628700877, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3807793465628700877, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3807793465628700877, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 3807793465628700877, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -8.88815
+      objectReference: {fileID: 0}
+    - target: {fileID: 3827423281839578266, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3827423281839578266, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3827423281839578266, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 92.83195
+      objectReference: {fileID: 0}
+    - target: {fileID: 3827423281839578266, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -33.82825
       objectReference: {fileID: 0}
     - target: {fileID: 4199903223617759707, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
       propertyPath: m_AnchorMax.y
@@ -6425,12 +6521,16 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4917401685761887966, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 150
+      objectReference: {fileID: 0}
+    - target: {fileID: 4917401685761887966, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 240
       objectReference: {fileID: 0}
     - target: {fileID: 4917401685761887966, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -85
+      value: -235
       objectReference: {fileID: 0}
     - target: {fileID: 5700981785730242236, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6488,6 +6588,38 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6069985282873653434, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6173418288519073210, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6704509902645770283, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6704509902645770283, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6704509902645770283, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -54.9401
+      objectReference: {fileID: 0}
+    - target: {fileID: 7257658390406289262, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7257658390406289262, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7257658390406289262, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 240
+      objectReference: {fileID: 0}
     - target: {fileID: 8019009251430727038, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
@@ -6512,6 +6644,34 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
+    - target: {fileID: 8245686989198471761, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8245686989198471761, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8245686989198471761, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -15
+      objectReference: {fileID: 0}
+    - target: {fileID: 8433239949674833187, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8433239949674833187, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8433239949674833187, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 174.4367
+      objectReference: {fileID: 0}
+    - target: {fileID: 8433239949674833187, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -10
+      objectReference: {fileID: 0}
     - target: {fileID: 9001344802587630794, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
@@ -6525,6 +6685,7 @@ PrefabInstance:
     - {fileID: 3737918403777358260, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
     - {fileID: 3551308965000692806, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
     - {fileID: 6127715804566686186, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
+    - {fileID: 4736077283920555134, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
     m_AddedGameObjects:
     - targetCorrespondingSourceObject: {fileID: 5700981785730242236, guid: 3ca6f79736a0bc14dab0531dc30c1a03, type: 3}
       insertIndex: -1

--- a/src/Assets/Scripts/UI/Settings/Settings.cs
+++ b/src/Assets/Scripts/UI/Settings/Settings.cs
@@ -6,7 +6,7 @@ using UnityEngine.UI;
 
 public class Settings : SubMenu
 {
-    public Button BackButton, SaveButton;
+    public Button BackButton;
     public Slider MasterVolumeSlider;
     public Text MasterVolumeText;
     private SettingsLoader settingsLoader;
@@ -38,14 +38,10 @@ public class Settings : SubMenu
         MenuController menuController = MenuController.Instance;
 
         HookButton(BackButton, menuController.GoBack);
-        HookButton(SaveButton, SaveClick);
-    }
-
-    private void SaveClick() {
-        masterVolumeSetting.Set(MasterVolumeSlider.value);
     }
 
     private void MasterVolumeAdjusted() {
         MasterVolumeText.text = $"{MasterVolumeSlider.value}%";
+        masterVolumeSetting.Set(MasterVolumeSlider.value);
     }
 }


### PR DESCRIPTION
Removes the "save" button from the settings menu and defaults to just updating the settings as you change them.

# How to test
- Go to settings
- Change volume slider
- Press back
- Go back to settings
- Observe if the volume setting saved or not
(You should also be able to hear the music volume change and be persistent)

Logic is almost entirely the same and just removed/moved a few lines.