### PR TITLE
Fixed inventory system softlocking when trying to place items

### DIFF
--- a/src/Assets/Scripts/InventorySystem/ItemDropNode.cs
+++ b/src/Assets/Scripts/InventorySystem/ItemDropNode.cs
@@ -124,23 +124,15 @@ public class ItemDropNode : MonoBehaviour
     public bool ItemIncoming(GameObject itemPrefab) {
         // Do we even allow this item in this node?
         if (AllowDeny.IsItemAllowed(itemPrefab.name) && !(SingleUse && used)) {
-            if (ActiveItem != null) {
-                // Call some abitrary function that runs when one item is dragged onto the other
-                // ActiveItem.GetComponent<PickupObject>().DraggedOnto(prefab);
-
-                // Disabled item mixing for vertical slice
-                // Its producing some issues that will be tackled for beta
-                return false;
-            } else {
+            if (ActiveItem == null) {
                 inventorySystem.CarriedItem = itemPrefab;
                 inventorySystem.HasMouseItem = false;
 
                 return true;
             }
 
-            return true;
-        } else
-        {
+            return false;
+        } else {
             BarkManager.Instance.OnPlacedItemFailed(gameObject, itemPrefab);
 
             return false;


### PR DESCRIPTION
It turns out this bug was caused because #245 (I believe inadvertently) overwrote some code I wrote in #243 which is fun. It caused some logic to be broken and some logic to be unreachable.

## How to test
- Pick up the kibble and put it in the bowl as intended
- Make sure all animations play, the player actually walks to the bowl, etc
- Try like 3 times to make sure you didn't get lucky but in my testing this softlock should be fixed