### PR TITLE
Fixed level3 broken references and softlocking

### DIFF
--- a/src/Assets/Scenes/Levels/Level3.unity
+++ b/src/Assets/Scenes/Levels/Level3.unity
@@ -7708,9 +7708,9 @@ MonoBehaviour:
   FillUpPointInitial: {fileID: 880909975}
   FillUpPointFuture: {fileID: 282041945}
   BurningBush: {fileID: 472798668}
-  FullBucket: {fileID: 653100337}
+  FullBucket: {fileID: 212373334936704344, guid: 7e063a3ff37f36062a661227f55435a6, type: 3}
   TimePortal: {fileID: 1056293028}
-  BushFire: {fileID: 0}
+  BushFire: {fileID: 653100340}
 --- !u!1001 &1281600973
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
So for some reason the level3 manager was missing a reference to the bush fire and it thought that the fire was a bucket...?

<img width="259" height="36" alt="image" src="https://github.com/user-attachments/assets/9e432655-dba7-4704-b9f3-ccf8eae836f2" />

Pretty funny.

## How to test
Just play through the level as intended and make sure there are no errors or softlocks when dealing with the bucket and putting out the fire.