### PR TITLE
Reimplement stacking for buckets

### DIFF
--- a/src/Assets/Prefabs/Items/BucketEmpty.prefab
+++ b/src/Assets/Prefabs/Items/BucketEmpty.prefab
@@ -34,7 +34,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3054084485680338735, guid: ee86283cb43e5a4c999a73c9ea42af9b, type: 3}
       propertyPath: AllowStacking
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3054084485680338735, guid: ee86283cb43e5a4c999a73c9ea42af9b, type: 3}
       propertyPath: AlternateGroundSprite

--- a/src/Assets/Prefabs/Items/BucketFilled.prefab
+++ b/src/Assets/Prefabs/Items/BucketFilled.prefab
@@ -34,7 +34,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3054084485680338735, guid: ee86283cb43e5a4c999a73c9ea42af9b, type: 3}
       propertyPath: AllowStacking
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3054084485680338735, guid: ee86283cb43e5a4c999a73c9ea42af9b, type: 3}
       propertyPath: AlternateGroundSprite

--- a/src/Assets/Scenes/Levels/Level5.unity.orig.meta
+++ b/src/Assets/Scenes/Levels/Level5.unity.orig.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d80bc01260f1338f192c396a5e5ed7c6
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Assets/Scripts/InventorySystem/PickupObject.cs
+++ b/src/Assets/Scripts/InventorySystem/PickupObject.cs
@@ -42,9 +42,7 @@ public class PickupObject : MonoBehaviour
         if (itemDropNode != null && inventorySystem.CarriedItem == null) {
             bool accepted = itemDropNode.ItemIncoming(PickupObjectPrefab);
 
-            if (!accepted) {
-                inventorySystem.AddItem(PickupObjectPrefab);
-            } else {
+            if (accepted) {
                 player.PathfindTo(itemDropNode.gameObject.transform.position);
             }
         }

--- a/src/Assets/Scripts/Levels/Level3/Puzzle3Manager.cs
+++ b/src/Assets/Scripts/Levels/Level3/Puzzle3Manager.cs
@@ -28,8 +28,8 @@ public class Puzzle3Manager : MonoBehaviour
         if (FillUpPointInitial.ActiveItem != null && TimeManager.Instance.IsFuture()) {
             FillUpPointFuture.ActiveItem = FullBucket;
             FillUpPointFuture.InitializeSprite();
-            FillUpPointInitial.ActiveItem = null;
-            FillUpPointInitial.InitializeSprite();
+            // FillUpPointInitial.ActiveItem = null;
+            // FillUpPointInitial.InitializeSprite();
         }
     }
 

--- a/src/Assets/Scripts/Levels/Level3/Puzzle3Manager.cs
+++ b/src/Assets/Scripts/Levels/Level3/Puzzle3Manager.cs
@@ -28,8 +28,6 @@ public class Puzzle3Manager : MonoBehaviour
         if (FillUpPointInitial.ActiveItem != null && TimeManager.Instance.IsFuture()) {
             FillUpPointFuture.ActiveItem = FullBucket;
             FillUpPointFuture.InitializeSprite();
-            // FillUpPointInitial.ActiveItem = null;
-            // FillUpPointInitial.InitializeSprite();
         }
     }
 
@@ -37,6 +35,6 @@ public class Puzzle3Manager : MonoBehaviour
         PathNetwork pathNetwork = PathNetwork.Instance;
 
         pathNetwork.SetPathPastTraversable(pathNetwork.GetNamedPath("bush"), true);
-        BushFire.Stop();
+        Destroy(BushFire);
     }
 }


### PR DESCRIPTION
Basically lets you stack the buckets now because of time travel. I am sure this will allow you to softlock the game in new and fun ways.

>[!NOTE]
> I don't think this is super necessary for gold. If we think its too much risk to add more bugs, we can probably get away without having this.
> This just adds more 'logic' to how the time traveling works in the bush fire level.

This also fixes a small issue with item stacking where if the system rejected placement of an item, it would duplicate that item. This also fixes an issue (that I think has always existed), where the fire starts burning again after you put it out and go back through a portal (not the usual route people would take but its possible).

<img width="298" height="133" alt="image" src="https://github.com/user-attachments/assets/4149477a-fef7-4e60-8c16-1a8d448c6942" />

# How to test
Try placing duplicating the bucket by traveling back and forth through time. Make sure the level can still be completed and that there are no weird continuity errors with the buckets.