### PR TITLE
Fixed a bug where clicking the dog bowl before picking up kibble disables it

### DIFF
--- a/src/Assets/ProgrammerArt/Shelf.png.orig.meta
+++ b/src/Assets/ProgrammerArt/Shelf.png.orig.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 033e2824becdb0407a0c9dc2eabd8a4c
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/src/Assets/Scripts/InventorySystem/ItemDropNode.cs
+++ b/src/Assets/Scripts/InventorySystem/ItemDropNode.cs
@@ -155,6 +155,8 @@ public class ItemDropNode : MonoBehaviour
                         InitializeSprite();
                         ItemRemoved?.Invoke();
                     }));
+
+                MarkUsed();
             } else if (inventorySystem.CarriedItem) {
                 SetActiveItem(inventorySystem.CarriedItem);
 
@@ -166,9 +168,9 @@ public class ItemDropNode : MonoBehaviour
                         InitializeSprite();
                         ItemPlaced?.Invoke();
                     }));
-            }
 
-            MarkUsed();
+                MarkUsed();
+            }
 
             player.StopInPlace();
             inventorySystem.Cancel();


### PR DESCRIPTION
Before, if you entered the cabin level and clicked the bowl when it was empty and you had nothing in hand, it would disable the bowl and softlock the game.

## How to test
- Load the cabin level
- Click on the bowl as if you were interacting with it
- Then go pick up the kibble
- Put the kibble in the bowl (this originally wouldn't work in this scenario)